### PR TITLE
Fix #253. Fix #243.

### DIFF
--- a/src/scripts/components/dialog/share-board.js
+++ b/src/scripts/components/dialog/share-board.js
@@ -78,7 +78,6 @@ export default React.createClass({
 							onClick={this.highlight}
 							name="board-share"
 							placeholder={this.locale('SHAREBOARD_LINK')}
-							readOnly={true}
 							value={sharedURL}
 							tabIndex={-1}/>
 						{shareButton}

--- a/src/scripts/views/board.js
+++ b/src/scripts/views/board.js
@@ -75,8 +75,13 @@ export default React.createClass({
 	},
 
 	componentDidMount() {
+		// start a 'pinger', which will ping other users every n secods
 		this.pinger = setInterval(
-			() => ActivityAction.createPing(this.props.id), 2000);
+			() => ActivityAction.createPing(this.props.id), 30000);
+
+		// create an initial 'ping'
+		ActivityAction.createPing(this.props.id);
+
 		BoardAction.load(this.props.id);
 		document.addEventListener('touchmove', preventDefault);
 	},


### PR DESCRIPTION
Remove the 'readonly' attribute from the share board input seems to
have fixed most of the issues with the copying on mobile devices.
Set the 'BOARD_PING' event to happen once initially and then every
30 seconds.
